### PR TITLE
Reference correct file in package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "gel-sass-tools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/bbc/gel-sass-tools",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"
   ],
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
-  "main": "_gel-sass-tools.scss",
+  "main": "_sass-tools.scss",
   "keywords": [
     "settings",
     "sass",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gel-sass-tools",
   "version": "1.1.1",
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
-  "main": "_gel-sass-tools.scss",
+  "main": "_sass-tools.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-sass-tools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
   "main": "_sass-tools.scss",
   "scripts": {


### PR DESCRIPTION
The current `package.json` file doesn't contain the right reference to the main `_sass-tools.scss` file, this means that trying to resolve the package using loaders such as https://www.npmjs.com/package/sass-module-importer fails.