### PR TITLE
feat: Using / for division is deprecated

### DIFF
--- a/lib/tools/_math.scss
+++ b/lib/tools/_math.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 ///*------------------------------------*\
 //    # MATH
 //\*------------------------------------*/
@@ -16,15 +18,15 @@
 // @author          Harry Roberts - http://bit.ly/1NTThPq
 //
 @function quarter($gel-number) {
-    @return round($gel-number / 4);
+    @return round(math.div($gel-number, 4));
 }
 
 @function third($gel-number) {
-    @return round($gel-number / 3);
+    @return round(math.div($gel-number, 3));
 }
 
 @function halve($gel-number) {
-    @return round($gel-number / 2);
+    @return round(math.div($gel-number, 2));
 }
 
 @function double($gel-number) {

--- a/lib/tools/_rem.scss
+++ b/lib/tools/_rem.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 ///*------------------------------------*\
 //    # REM
 //\*------------------------------------*/
@@ -45,7 +47,7 @@ $gel-tools-rem-enable--fallback: true !default;
         @return $result;
     }
 
-    @return if(type-of($value) == number and unit($value) == px, $value / $baseline * 1rem, $value);
+    @return if(type-of($value) == number and unit($value) == px, math.div($value, $baseline) * 1rem, $value);
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-sass-tools",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,8 +10,8 @@
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "normalize-path": "3.0.0",
+        "picomatch": "2.3.0"
       }
     },
     "binary-extensions": {
@@ -26,23 +26,23 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "7.0.1"
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "anymatch": "3.1.2",
+        "braces": "3.0.2",
+        "fsevents": "2.3.2",
+        "glob-parent": "5.1.2",
+        "is-binary-path": "2.1.0",
+        "is-glob": "4.0.3",
+        "normalize-path": "3.0.0",
+        "readdirp": "3.6.0"
       }
     },
     "fill-range": {
@@ -51,7 +51,7 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "to-regex-range": "^5.0.1"
+        "to-regex-range": "5.0.1"
       }
     },
     "fsevents": {
@@ -67,7 +67,7 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
-        "is-glob": "^4.0.1"
+        "is-glob": "4.0.3"
       }
     },
     "is-binary-path": {
@@ -76,7 +76,7 @@
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
-        "binary-extensions": "^2.0.0"
+        "binary-extensions": "2.2.0"
       }
     },
     "is-extglob": {
@@ -86,12 +86,12 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-number": {
@@ -107,33 +107,33 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.2.1"
+        "picomatch": "2.3.0"
       }
     },
     "sass": {
-      "version": "1.32.12",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
-      "integrity": "sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
       "dev": true,
       "requires": {
-        "chokidar": ">=3.0.0 <4.0.0"
+        "chokidar": "3.5.2"
       }
     },
     "sass-mq": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-3.2.3.tgz",
-      "integrity": "sha1-n4dL+h69IhD8L7Tlm4dA35ip4ug="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
+      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -141,7 +141,7 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "^7.0.0"
+        "is-number": "7.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-sass-tools",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
   "main": "_sass-tools.scss",
   "scripts": {
@@ -34,10 +34,10 @@
   },
   "homepage": "https://github.com/bbc/gel-sass-tools",
   "dependencies": {
-    "sass-mq": "3.2.3"
+    "sass-mq": "5.0.1"
   },
   "devDependencies": {
-    "sass": "1.32.12",
+    "sass": "1.42.1",
     "sass-mq": "5.0.1"
   }
 }


### PR DESCRIPTION
## Description
Switches to use `math.div` instead of ` / ` as Dart 2 will not support it
and is already displaying deprecation warnings.

## Issue
https://github.com/bbc/gel-grid/issues/48