### PR TITLE
chore: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,30 +130,30 @@ or functions can be nested within other Sass features such as mixins:
 
 ```sass
 .my-component {
-    @include rem('margin-bottom', halve($gel-spacing-unit));
-    @include rem('padding-left', double($gel-spacing-unit));
-    @include rem('padding-right', double($gel-spacing-unit));
+    @include toRem('margin-bottom', halve($gel-spacing-unit));
+    @include toRem('padding-left', double($gel-spacing-unit));
+    @include toRem('padding-right', double($gel-spacing-unit));
 }
 ```
 
 ### REM mixin
 
-The `rem` tool can be used in two ways. Either by directly calling the `rem($value)` function, which will convert the supplied value and return a `rem` unit. E.g:
+The `rem` tool can be used in two ways. Either by directly calling the `toRem($value)` function, which will convert the supplied value and return a `rem` unit. E.g:
 
 ```sass
 .my-component {
-    margin-bottom: rem($gel-spacing-unit);
+    margin-bottom: toRem($gel-spacing-unit);
 }
 ```
 
 > Beware that [rem](http://caniuse.com/#feat=rem) units are not universal supported. IE8 and below do not support `rem` so require a `px` fallback.
 
-You can also use the `@include rem($value);` mixin, which by default returns a `px` fallback to allow support for older browsers which don't support `rem` units. E.g:
+You can also use the `@include toRem($value);` mixin, which by default returns a `px` fallback to allow support for older browsers which don't support `rem` units. E.g:
 
 **Sass**
 ```sass
 .my-component {
-    @include rem('margin-bottom', 16px);
+    @include toRem('margin-bottom', 16px);
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gel-sass-tools",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gel-sass-tools",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "sass-mq": "6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-sass-tools",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
   "main": "_sass-tools.scss",
   "scripts": {


### PR DESCRIPTION
## Description
Updates the README to flect the change in name for the function and mixin (now called `toRem` instead of `rem`).

## Issue
https://jira.dev.bbc.co.uk/browse/GEL-2103