### PR TITLE
fix: Use sass loadpaths

### DIFF
--- a/lib/settings/_globals.scss
+++ b/lib/settings/_globals.scss
@@ -1,4 +1,4 @@
-@use '../../node_modules/sass-mq/mq' as mq;
+@use 'sass-mq/mq' as mq;
 @use 'sass:list';
 @use 'sass:map';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gel-sass-tools",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gel-sass-tools",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "sass-mq": "7.0.0-beta.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-sass-tools",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
   "main": "_sass-tools.scss",
   "scripts": {

--- a/test/setup-jest.js
+++ b/test/setup-jest.js
@@ -1,7 +1,7 @@
 const sass = require('sass');
 
 global.compileCSS = async (filePath = '') => {
-  const { css } = await sass.compileAsync(filePath);
+  const { css } = await sass.compileAsync(filePath, { loadPaths: ['./node_modules'] });
 
   return css;
 };


### PR DESCRIPTION
## Description
As the scss modules reference other node_modules there's a need to use loadpaths so the relevant scss dependency can always be found (relative paths are liable to break on different systems).

## Issue
https://jira.dev.bbc.co.uk/browse/GEL