### PR TITLE
feat: Use sass namespacing

### DIFF
--- a/lib/settings/_globals.scss
+++ b/lib/settings/_globals.scss
@@ -110,8 +110,3 @@ $gel-breakpoints: ();
 
 // MQ expects a Sass Map containing the available breakpoints
 mq.$breakpoints: $gel-breakpoints;
-
-
-
-// Define a variable so we can tell the other components the settings are available
-$gel-settings-available: true;

--- a/lib/tools/_flip.scss
+++ b/lib/tools/_flip.scss
@@ -1,11 +1,11 @@
-@use '../settings/rtl' as *;
+@use '../settings/rtl';
 
 ///*------------------------------------*\
 //    # FLIP
 //\*------------------------------------*/
 
 // The flip function switches between the two provided arguements
-// based on the value of the globally defined $rtl value.
+// based on the value of the globally defined rtl.$rtl value.
 //
 // This can be used to toggle between values which need to change
 // when we want right-to-left support.
@@ -20,7 +20,7 @@
 // @return {String}    The correct value based on the value of $rtl
 //
 @function flip($ltr-value, $rtl-value) {
-    @if $rtl {
+    @if rtl.$rtl {
         @return $rtl-value;
     }
 

--- a/lib/tools/_rem.scss
+++ b/lib/tools/_rem.scss
@@ -1,18 +1,10 @@
 @use 'sass:math';
 @use 'sass:meta';
-@use '../settings/globals' as *;
+@use '../settings/globals';
 
 ///*------------------------------------*\
 //    # REM
 //\*------------------------------------*/
-
-// We need to check that the GEL settings are available globally
-$gel-settings-available: false !default;
-@if ($gel-settings-available == false) {
-  @warn "Missing Dependency: Have you included the GEL settings?";
-}
-
-
 $gel-tools-rem-enable--function: true !default;
 $gel-tools-rem-enable--mixin: true !default;
 $gel-tools-rem-enable--fallback: true !default;
@@ -22,13 +14,13 @@ $gel-tools-rem-enable--fallback: true !default;
 // for whatever property is passed to it.
 //
 // @param {Int}     $value - The unit you want converting to a rem unit
-// @param {Int}     $baseline ($gel-base-font-size) - The base font size of the page
+// @param {Int}     $baseline (globals.$gel-base-font-size) - The base font size of the page
 //
 // @return {Int}    The supplied converted to a rem unit
 //
 // @author          Kaelig - https://github.com/guardian/guss-rem
 //
-@function toRem($value, $baseline: $gel-base-font-size) {
+@function toRem($value, $baseline: globals.$gel-base-font-size) {
 
     // if function is disabled then return the value
     @if ($gel-tools-rem-enable--function == false) {


### PR DESCRIPTION
## Description
Updates to use SASS name-spacing to ensure it means best practice at this time. As the way that stylesheets are now used is different there's also no need for the check to see that the settings (`$gel-settings-available`) are loaded, as they are loaded by default.

## Issue
https://jira.dev.bbc.co.uk/browse/GEL