### PR TITLE
chore: Remove $gel-breakpoint-static variable

### DIFF
--- a/lib/settings/_globals.scss
+++ b/lib/settings/_globals.scss
@@ -83,11 +83,6 @@ $gel-breakpoint-names: (xs, s, m, l, xl, xxl) !default;
 //
 $gel-breakpoint-sizes: (240px, 400px, 600px, 900px, 1008px, 1280px) !default;
 
-// If we're generating a fixed width output which breakpoint to use as the maximum
-//
-// @type String
-//
-$gel-breakpoint-static: gel-bp-l !default;
 
 
 // Loop through each of our breakpoint-sizes, map this with the appropriate name


### PR DESCRIPTION
This variable was passed along to `sass-mq`, however as the variable in sass-mq was removed in v6 there is no longer any purpose for the gel variable.