### PR TITLE
chore: Avoid pre and post scripts

### DIFF
--- a/codebuild/releasespec.yml
+++ b/codebuild/releasespec.yml
@@ -17,7 +17,7 @@ phases:
     on-failure: ABORT
     commands:
       - npm test
- 
+
   post_build:
     on-failure: ABORT
     commands:

--- a/lib/settings/_globals.scss
+++ b/lib/settings/_globals.scss
@@ -11,7 +11,6 @@
 // adjusted directly; you should predefine the variables in your own project,
 // to overide these default settings.
 
-
 /// Namespace
 //
 // By default all GEL components are namespaced with `gel-`, this allows us to
@@ -21,8 +20,6 @@
 // @type String
 //
 $gel-namespace: 'gel-' !default;
-
-
 
 /// Spacing
 //
@@ -41,8 +38,6 @@ $gel-spacing-unit: 8px !default;
 //
 $gel-alt-spacing-unit: 12px !default;
 
-
-
 /// Base settings
 //
 // Base settings are used primarly by our tools at the moment but there use could change in
@@ -54,8 +49,6 @@ $gel-alt-spacing-unit: 12px !default;
 // @type Number (with units)
 //
 $gel-base-font-size: 16px !default;
-
-
 
 /// Breakpoints
 //
@@ -83,19 +76,20 @@ $gel-breakpoint-names: (xs, s, m, l, xl, xxl) !default;
 //
 $gel-breakpoint-sizes: (240px, 400px, 600px, 900px, 1008px, 1280px) !default;
 
-
-
 // Loop through each of our breakpoint-sizes, map this with the appropriate name
 // and append it to the $gel-breakpoints map.
 $gel-breakpoints: ();
 @each $breakpoint in $gel-breakpoint-sizes {
-    $i: list.index($gel-breakpoint-sizes, $breakpoint);
-    $breakpoint-name: #{$gel-breakpoint-prefix}#{list.nth($gel-breakpoint-names, $i)};
+  $i: list.index($gel-breakpoint-sizes, $breakpoint);
+  $breakpoint-name: #{$gel-breakpoint-prefix}#{list.nth($gel-breakpoint-names, $i)};
 
-    $gel-breakpoints: map.merge($gel-breakpoints, ($breakpoint-name: $breakpoint)) !global;
+  $gel-breakpoints: map.merge(
+    $gel-breakpoints,
+    (
+      $breakpoint-name: $breakpoint,
+    )
+  ) !global;
 }
-
-
 
 /// MQ Config
 //

--- a/lib/settings/_rtl.scss
+++ b/lib/settings/_rtl.scss
@@ -9,7 +9,6 @@
 // Values can be adjusted using the `flip` function and properties adjusted using the
 // interpolation variables.
 
-
 /// RTL
 //
 // By default RTL support is disabled. This can be enabled by defining an `$rtl` variable
@@ -19,8 +18,6 @@
 // @type Bool
 //
 $rtl: false !default;
-
-
 
 /// Interpolated Properties
 //
@@ -35,37 +32,36 @@ $rtl: false !default;
 //
 // @type String
 //
-$margin-right:       'margin-right' !default;
-$margin-left:        'margin-left' !default;
-$border-right:       'border-right' !default;
-$border-left:        'border-left' !default;
-$border-left-width:  'border-left-width' !default;
+$margin-right: 'margin-right' !default;
+$margin-left: 'margin-left' !default;
+$border-right: 'border-right' !default;
+$border-left: 'border-left' !default;
+$border-left-width: 'border-left-width' !default;
 $border-right-width: 'border-right-width' !default;
-$border-left-color:  'border-left-color' !default;
+$border-left-color: 'border-left-color' !default;
 $border-right-color: 'border-right-color' !default;
-$border-left-style:  'border-left-style' !default;
+$border-left-style: 'border-left-style' !default;
 $border-right-style: 'border-right-style' !default;
-$padding-right:      'padding-right' !default;
-$padding-left:       'padding-left' !default;
-$right:              'right' !default;
-$left:               'left' !default;
-
+$padding-right: 'padding-right' !default;
+$padding-left: 'padding-left' !default;
+$right: 'right' !default;
+$left: 'left' !default;
 
 // If the `$rtl` variable is `true` flip the direction of the interpolated properties
 //
 @if $rtl {
-    $margin-right:       'margin-left';
-    $margin-left:        'margin-right';
-    $border-right:       'border-left';
-    $border-left:        'border-right';
-    $border-left-width:  'border-right-width';
-    $border-right-width: 'border-left-width';
-    $border-left-color:  'border-right-color';
-    $border-right-color: 'border-left-color';
-    $border-left-style:  'border-right-style';
-    $border-right-style: 'border-left-style';
-    $padding-right:      'padding-left';
-    $padding-left:       'padding-right';
-    $right:              'left';
-    $left:               'right';
+  $margin-right: 'margin-left';
+  $margin-left: 'margin-right';
+  $border-right: 'border-left';
+  $border-left: 'border-right';
+  $border-left-width: 'border-right-width';
+  $border-right-width: 'border-left-width';
+  $border-left-color: 'border-right-color';
+  $border-right-color: 'border-left-color';
+  $border-left-style: 'border-right-style';
+  $border-right-style: 'border-left-style';
+  $padding-right: 'padding-left';
+  $padding-left: 'padding-right';
+  $right: 'left';
+  $left: 'right';
 }

--- a/lib/tools/_flip.scss
+++ b/lib/tools/_flip.scss
@@ -20,9 +20,9 @@
 // @return {String}    The correct value based on the value of $rtl
 //
 @function flip($ltr-value, $rtl-value) {
-    @if rtl.$rtl {
-        @return $rtl-value;
-    }
+  @if rtl.$rtl {
+    @return $rtl-value;
+  }
 
-    @return $ltr-value;
+  @return $ltr-value;
 }

--- a/lib/tools/_math.scss
+++ b/lib/tools/_math.scss
@@ -18,25 +18,25 @@
 // @author          Harry Roberts - http://bit.ly/1NTThPq
 //
 @function quarter($gel-number) {
-    @return math.round(math.div($gel-number, 4));
+  @return math.round(math.div($gel-number, 4));
 }
 
 @function third($gel-number) {
-    @return math.round(math.div($gel-number, 3));
+  @return math.round(math.div($gel-number, 3));
 }
 
 @function halve($gel-number) {
-    @return math.round(math.div($gel-number, 2));
+  @return math.round(math.div($gel-number, 2));
 }
 
 @function double($gel-number) {
-    @return math.round($gel-number * 2);
+  @return math.round($gel-number * 2);
 }
 
 @function triple($gel-number) {
-    @return math.round($gel-number * 3);
+  @return math.round($gel-number * 3);
 }
 
 @function quadruple($gel-number) {
-    @return math.round($gel-number * 4);
+  @return math.round($gel-number * 4);
 }

--- a/lib/tools/_rem.scss
+++ b/lib/tools/_rem.scss
@@ -9,7 +9,6 @@ $gel-tools-rem-enable--function: true !default;
 $gel-tools-rem-enable--mixin: true !default;
 $gel-tools-rem-enable--fallback: true !default;
 
-
 // 'rem' is a Sass function that converts pixel values to rem values
 // for whatever property is passed to it.
 //
@@ -21,30 +20,31 @@ $gel-tools-rem-enable--fallback: true !default;
 // @author          Kaelig - https://github.com/guardian/guss-rem
 //
 @function toRem($value, $baseline: globals.$gel-base-font-size) {
+  // if function is disabled then return the value
+  @if ($gel-tools-rem-enable--function == false) {
+    @return $value;
+  }
 
-    // if function is disabled then return the value
-    @if ($gel-tools-rem-enable--function == false) {
-        @return $value;
+  @if $value == 0 {
+    @return 0; // 0rem -> 0
+  }
+
+  @if meta.type-of($value) == list {
+    $result: ();
+
+    @each $e in $value {
+      $result: append($result, rem($e, $baseline));
     }
 
-    @if $value == 0 {
-        @return 0; // 0rem -> 0
-    }
+    @return $result;
+  }
 
-    @if meta.type-of($value) == list {
-        $result: ();
-
-        @each $e in $value {
-            $result: append($result, rem($e, $baseline));
-        }
-
-        @return $result;
-    }
-
-    @return if(meta.type-of($value) == number and math.unit($value) == px, math.div($value, $baseline) * 1rem, $value);
+  @return if(
+    meta.type-of($value) == number and math.unit($value) == px,
+    math.div($value, $baseline) * 1rem,
+    $value
+  );
 }
-
-
 
 // Converts pixel values to rem values for whatever property is passed to it. It returns two
 // lines of code — one of the regular pixel values (for old IE), and another with the
@@ -56,15 +56,13 @@ $gel-tools-rem-enable--fallback: true !default;
 // @author          Shaun Bent
 //
 @mixin toRem($property, $value) {
+  // Return the pixel value first
+  @if ($gel-tools-rem-enable--mixin == false or $gel-tools-rem-enable--fallback == true) {
+    #{$property}: $value;
+  }
 
-    // Return the pixel value first
-    @if ($gel-tools-rem-enable--mixin == false or $gel-tools-rem-enable--fallback == true) {
-        #{$property}: $value;
-    }
-
-    // Pass the px value into the rem function
-    @if ($gel-tools-rem-enable--function == true and $gel-tools-rem-enable--mixin == true) {
-        #{$property}: toRem($value);
-    }
-
+  // Pass the px value into the rem function
+  @if ($gel-tools-rem-enable--function == true and $gel-tools-rem-enable--mixin == true) {
+    #{$property}: toRem($value);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A collection of Sass Settings & Tools which align to key GEL values",
   "main": "_sass-tools.scss",
   "scripts": {
-    "prettier": "prettier --write '{src/**/*,test/**/*,*}.{js,json,mjs,scss}'",
-    "pretest": "npm run prettier",
-    "test": "jest"
+    "build": "echo \"Error: no build step required\" && exit 1",
+    "jest": "jest",
+    "prettier": "prettier . '!**/*.md' --write",
+    "test": "npm run prettier && npm run jest"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Description
Using `npm config set ignore-scripts true` means that any scripts with `pre...` and `post...` will no longer run. Whilst this may improve the security around npm scripts it does mean that the workflows need to be adjusted - which is what this PR does.

At the same time the package.json prettier command has been updated to ensure more files are formatted consistently.